### PR TITLE
handles transaction timestamps correctly for bbc1 core 1.3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ people who have submitted patches, reported bugs, added translations, helped
 answer newbie questions, and generally made BBc-1 that much better:
 
     Kenji Saito        <ks91@beyond-blockchain.org>
+    kichinosukey       <kichinosuke.fukuhara@gmail.com>

--- a/bbc1/lib/app_support_lib.py
+++ b/bbc1/lib/app_support_lib.py
@@ -42,6 +42,19 @@ def get_support_dir(domain_id):
     return s_dir
 
 
+def get_timestamp_in_seconds(transaction):
+    """Gets timestamp of a transaction in seconds.
+
+    Args:
+        transaction (BBcTransaction):
+
+    Return:
+        timestamp (int):
+
+    """
+    return transaction.timestamp // 1000
+
+
 class Constants:
 
     MAX_INT8  = 0x7f

--- a/bbc1/lib/id_lib.py
+++ b/bbc1/lib/id_lib.py
@@ -21,6 +21,7 @@ import time
 sys.path.append("../../")
 
 from bbc1.lib import app_support_lib
+from bbc1.lib.app_support_lib import get_timestamp_in_seconds
 from bbc1.core import bbclib
 from bbc1.core.libs import bbclib_utils
 from bbc1.core import logger, bbc_app
@@ -177,7 +178,7 @@ class BBcIdPublickeyMap:
 
         if eval_time is None:
             eval_time = int(time.time())
-        while tx.timestamp > eval_time:
+        while get_timestamp_in_seconds(tx) > eval_time:
             self.__undo_public_keys(public_keys, tx.transaction_id, user_id)
             tx = self.__get_referred_transaction(tx)
             if tx is None:
@@ -207,7 +208,7 @@ class BBcIdPublickeyMap:
         if eval_time is None:
             eval_time = int(time.time())
 
-        while tx.timestamp > eval_time:
+        while get_timestamp_in_seconds(tx) > eval_time:
             self.__undo_user_ids(user_ids, tx.transaction_id, user_id,
                     public_key)
             tx = self.__get_referred_transaction(tx)
@@ -324,7 +325,7 @@ class BBcIdPublickeyMap:
                 else:
                     if self.is_mapped(user_id,
                             transaction.signatures[idx].pubkey,
-                            transaction.timestamp):
+                            get_timestamp_in_seconds(transaction)):
                         return True
             except:
                 return False
@@ -341,7 +342,7 @@ class BBcIdPublickeyMap:
                     for i in ref.sig_indices:
                         if self.is_mapped(approver,
                                 transaction.signatures[i].pubkey,
-                                transaction.timestamp):
+                                get_timestamp_in_seconds(transaction)):
                             signed = True
                             break
                     if signed == False:
@@ -351,7 +352,7 @@ class BBcIdPublickeyMap:
                     for i in ref.sig_indices:
                         if self.is_mapped(approver,
                                 transaction.signatures[i].pubkey,
-                                transaction.timestamp):
+                                get_timestamp_in_seconds(transaction)):
                             count += 1
                             break
                 if count < event.option_approver_num_numerator:

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,10 @@ bbc1_classifiers = [
 
 setup(
     name='bbc1-lib-std',
-    version='0.13',
+    version='0.14',
     description='Standard library of Beyond Blockchain One',
     long_description=readme,
-    url='https://github.com/beyond-blockchain/bbc1',
+    url='https://github.com/beyond-blockchain/bbc1-lib-std',
     author='beyond-blockchain.org',
     author_email='bbc1-dev@beyond-blockchain.org',
     license='Apache License 2.0',


### PR DESCRIPTION
bbc1 core v1.3 stores timestamps of transactions in milliseconds.
Many applications may want to handle the timestamps in seconds, so application_support_lib
provides a function to get timestamps in seconds, and id_lib uses it.
