### PR TITLE
handles key types for better crypto-agility. changed database design.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ bbc1_classifiers = [
 
 setup(
     name='bbc1-lib-std',
-    version='0.18',
+    version='0.19',
     description='Standard library of Beyond Blockchain One',
     long_description=readme,
     url='https://github.com/beyond-blockchain/bbc1-lib-std',

--- a/tests/test_id_lib.py
+++ b/tests/test_id_lib.py
@@ -67,12 +67,14 @@ def test_get_map(default_domain_id):
 
     assert len(keypairs) == NUM_KEYPAIRS
 
-    public_keys = idPubkeyMap.get_mapped_public_keys(user_id)
+    public_keys, key_types = idPubkeyMap.get_mapped_public_keys(user_id)
 
     assert len(public_keys) == NUM_KEYPAIRS
+    assert len(key_types) == NUM_KEYPAIRS
 
     for i in range(NUM_KEYPAIRS):
         assert bytes(keypairs[i].public_key) == public_keys[i]
+        assert keypairs[i].curvetype == key_types[i]
 
 
 def test_map_creation_with_pubkeys(default_domain_id):
@@ -139,9 +141,10 @@ def test_map_eval(default_domain_id):
 
     time3 = int(time.time())
 
-    public_keys = idPubkeyMap.get_mapped_public_keys(user_id, time3)
+    public_keys, key_types = idPubkeyMap.get_mapped_public_keys(user_id, time3)
 
     assert len(public_keys) == 3
+    assert len(key_types) == 3
 
     for keypair in keypairs1:
         assert bytes(keypair.public_key) in public_keys
@@ -151,9 +154,10 @@ def test_map_eval(default_domain_id):
     assert idPubkeyMap.is_mapped(user_id, keypairs1[1].public_key, time3) == True
     assert idPubkeyMap.is_mapped(user_id, keypairs1[2].public_key, time3) == True
 
-    public_keys = idPubkeyMap.get_mapped_public_keys(user_id, time2)
+    public_keys, key_types = idPubkeyMap.get_mapped_public_keys(user_id, time2)
 
     assert len(public_keys) == 1
+    assert len(key_types) == 1
 
     for keypair in keypairs0:
         assert bytes(keypair.public_key) in public_keys
@@ -163,9 +167,10 @@ def test_map_eval(default_domain_id):
     assert idPubkeyMap.is_mapped(user_id, keypairs1[1].public_key, time2) == False
     assert idPubkeyMap.is_mapped(user_id, keypairs1[2].public_key, time2) == False
 
-    public_keys = idPubkeyMap.get_mapped_public_keys(user_id, time1)
+    public_keys, key_types = idPubkeyMap.get_mapped_public_keys(user_id, time1)
 
     assert len(public_keys) == 4
+    assert len(key_types) == 4
 
     for keypair in keypairs0:
         assert bytes(keypair.public_key) in public_keys
@@ -177,9 +182,10 @@ def test_map_eval(default_domain_id):
     assert idPubkeyMap.is_mapped(user_id, keypairs1[1].public_key, time1) == True
     assert idPubkeyMap.is_mapped(user_id, keypairs1[2].public_key, time1) == True
 
-    public_keys = idPubkeyMap.get_mapped_public_keys(user_id, time0)
+    public_keys, key_types = idPubkeyMap.get_mapped_public_keys(user_id, time0)
 
     assert len(public_keys) == 1
+    assert len(key_types) == 1
 
     for keypair in keypairs0:
         assert bytes(keypair.public_key) in public_keys
@@ -192,12 +198,16 @@ def test_map_eval(default_domain_id):
     idPubkeyMap._BBcIdPublickeyMap__clear_local_database(user_id)
     print("cleared local database entries for the user for reconstruction.")
 
-    public_keys = idPubkeyMap.get_mapped_public_keys(user_id)
+    public_keys, key_types = idPubkeyMap.get_mapped_public_keys(user_id)
 
     assert len(public_keys) == 3
+    assert len(key_types) == 3
 
     for keypair in keypairs1:
         assert bytes(keypair.public_key) in public_keys
+
+    for key_type in key_types:
+        assert key_type == bbclib.DEFAULT_CURVETYPE
 
     assert idPubkeyMap.is_mapped(user_id, keypairs0[0].public_key) == False
     assert idPubkeyMap.is_mapped(user_id, keypairs1[0].public_key) == True
@@ -205,6 +215,50 @@ def test_map_eval(default_domain_id):
     assert idPubkeyMap.is_mapped(user_id, keypairs1[2].public_key) == True
 
     idPubkeyMap.close()
+
+
+def test_key_types(default_domain_id):
+
+    idPubkeyMap = id_lib.BBcIdPublickeyMap(default_domain_id,
+            default_key_type=bbclib.KeyType.ECDSA_SECP256k1)
+    user_id, keypairs = idPubkeyMap.create_user_id(num_pubkeys=1)
+
+    assert len(keypairs) == 1
+
+    assert idPubkeyMap.is_mapped(user_id, keypairs[0].public_key) == True
+
+    public_keys, key_types = idPubkeyMap.get_mapped_public_keys(user_id)
+
+    assert len(key_types) == 1
+    assert key_types[0] == bbclib.KeyType.ECDSA_SECP256k1
+
+    public_keys = []
+    key_types = []
+    for i in range(3):
+        if i == 1:
+            key_type = bbclib.KeyType.ECDSA_SECP256k1
+        else:
+            key_type = bbclib.KeyType.ECDSA_P256v1
+        keypair = bbclib.KeyPair(key_type)
+        keypair.generate()
+        public_keys.append(keypair.public_key)
+        key_types.append(key_type)
+
+    tx = idPubkeyMap.update(user_id, public_keys_to_replace=public_keys,
+            key_types_to_replace=key_types, keypair=keypairs[0])
+
+    assert idPubkeyMap.is_mapped(user_id, keypairs[0].public_key) == False
+    for i in range(3):
+        assert idPubkeyMap.is_mapped(user_id, public_keys[i]) == True
+
+    public_keys, key_types = idPubkeyMap.get_mapped_public_keys(user_id)
+
+    assert len(key_types) == 3
+    for i, key_type in enumerate(key_types):
+        if i == 1:
+            assert key_type == bbclib.KeyType.ECDSA_SECP256k1
+        else:
+            assert key_type == bbclib.KeyType.ECDSA_P256v1
 
 
 # end of tests/test_id_lib.py


### PR DESCRIPTION
Key types are stored in the id / public-key mapping in directives (events) of transaction data and in local database. Hopefully this makes digital signatures in BBc-1 applications more crypto-agile.

Since the database design is changed, ".bbc1_app_support" directory needs to be cleared before use. Transaction data is also incompatible (hope this is OK as the library is still at development stage).
